### PR TITLE
chore: Fix Onboard to a cluster guide link

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding_to_cluster.md
+++ b/.github/ISSUE_TEMPLATE/onboarding_to_cluster.md
@@ -33,4 +33,4 @@ Select all that apply:
 
 ---
 
-If you don't want to wait for the maintainers to notice this issue, you can do the changes yourself. Please follow the [docs/onboarding_to_cluster.md](../../docs/onboarding_to_cluster.md) guide.
+If you don't want to wait for the maintainers to notice this issue, you can do the changes yourself. Please follow the [docs/onboarding_to_cluster.md](https://github.com/operate-first/support/blob/main/docs/onboarding_to_cluster.md) guide.


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/45