### PR TITLE
docs: User data handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/ceph_bucket_request.md
+++ b/.github/ISSUE_TEMPLATE/ceph_bucket_request.md
@@ -1,0 +1,30 @@
+---
+name: "User support: S3 Storage request"
+about: "Template for users of ODH apps requesting S3/Ceph object storage."
+title: ""
+labels: user-support
+assignees: ""
+---
+
+### Questionnaire
+
+1. **User details**:
+   Your MOC user name and which applications deployed by our team you're planning to use the bucket at
+
+2. **Desired bucket name**:
+   Due to technical limitation we can't promise you a bucket name, instead we will use your preferred name as a prefix to the bucket name.
+
+3. **Maximal bucket size**:
+   Planned maximal total bucket size in GiB. Default quota is 2GiB.
+
+4. **Maximal bucket object count**:
+   Planned maximal count of objects in your bucket. Default quota is 10000.
+
+5. **Your GPG key or contact**:
+   Please specify, how we can reach out to you securely so we can share your bucket credentials and access details. Providing us with your GPG key is preferred. Example:
+
+   `0508677DD04952D06A943D5B4DC4116D360E3276` available from keys.gnupg.net
+
+---
+
+If you don't want to wait for the maintainers to notice this issue, you can do the changes yourself. Please follow the [docs/user_profiles.md](https://github.com/operate-first/support/blob/main/docs/user_profiles.md) guide.

--- a/.github/ISSUE_TEMPLATE/pvc_request.md
+++ b/.github/ISSUE_TEMPLATE/pvc_request.md
@@ -1,0 +1,19 @@
+---
+name: "User support: JupyterHub hardware requirements"
+about: "Template for users of JupyterHub requesting hardware quota upgrade: disk size, CPU/GPU/Memory."
+title: ""
+labels: user-support
+assignees: ""
+---
+
+### Questionnaire
+
+1. **User details**:
+   Your MOC user name
+
+2. **Desired resource change**:
+   Please specify what resource quota you want to change and what would be the desired limit for you.
+
+---
+
+If you don't want to wait for the maintainers to notice this issue, you can do the changes yourself. Please follow the [docs/user_profiles.md](https://github.com/operate-first/support/blob/main/docs/user_profiles.md) guide.

--- a/docs/user_profiles.md
+++ b/docs/user_profiles.md
@@ -1,0 +1,22 @@
+# Managing user profiles
+
+This document should help you manage the user profiles for ODH users.
+
+The following steps serves as a guide for maintenance on user profiles for ODH JupyterHub and global ceph buckets hosted on MOC clusters.
+
+## Prerequisites
+
+You will need pre-requisite tools to follow along with this doc, please do one of the following:
+
+- Install our [toolbox](https://github.com/operate-first/toolbox) to have the developer setup ready automatically for you.
+- Install the tools manually. You'll need [kustomize](https://kustomize.io/), [sops](https://github.com/mozilla/sops) and [ksops](https://github.com/viaduct-ai/kustomize-sops).
+
+Please fork/clone the [operate-first/apps](https://github.com/operate-first/apps) repository. **During this whole setup, we'll be working within this repository.**
+
+## JupyterHub user profiles and HW quota
+
+TBD, probably maintained within `apps` repo at `odh/overlays/TARGET_CLUSTER/jupyterhub/`?
+
+## Claiming Ceph bucket
+
+TBD, probably a separate application in `apps` repo?


### PR DESCRIPTION
Partials for: https://github.com/operate-first/support/issues/48 https://github.com/operate-first/apps/issues/100

This PR is a template, without the actual implementation details or a guide. I think that should follow up in separate PRs. I think we just need to have the issue templates in place, even without the actual how-to, so users can start filing in tickets.