### PR TITLE
Bring operate-first-workloads content to support

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,7 @@ If you are interested in bringing your project to the Operate First Environment 
 Projects are expected to work with the ops team in the open in github https://github.com/operate-first
 There is also work done to manage the infrastructure that can be found in the Open Infrastructure Labs project https://github.com/open-infrastructure-labs
 
-To see what’s happening right now, online chat is done at http://operatefirst.slack.com/. 
+To see what’s happening right now, online chat is done at http://operatefirst.slack.com/.
 There is an associated mailing list hosted by the MOC: Operate-first-users https://chat.google.com/room/AAAAAYpDdc8
 
 Open Infrastructure Labs also has a mailing list: Openinfralabs http://lists.opendev.org/cgi-bin/mailman/listinfo/openinfralabs
@@ -43,13 +43,12 @@ There are a few basic things that need to be understood about the Operate First 
 
 - Operating at the MOC never implies that any feature or software will ship. Thus a new feature that is being considered can be tested without any implied commitment.
 
-- Open Infrastructure Labs is an open source upstream aimed at cloud providers and operators and that is where much of the operate first work is being done. 
+- Open Infrastructure Labs is an open source upstream aimed at cloud providers and operators and that is where much of the operate first work is being done.
 
 - While a production cloud, the MOC is taking in pre-release software, and thus stability is not guaranteed, and should not be expected. No backup of user data is made. There is no SLA.
 
 - It’s free, but the cost is commitment. The MOC is not a place to bring a project and then leave. It’s expected that the developers will actively participate with the operators when needed and be available to help sort out issues.
 
-- The benefit to project developers is bringing back what’s learned to improve their project. 
+- The benefit to project developers is bringing back what’s learned to improve their project.
 
 - Also, projects need to agree that telemetry can be freely harvested from the cloud. It’s purpose is to help evolve open source cloud operations and it extends to building AI Ops tooling.
-


### PR DESCRIPTION
Part of: https://github.com/operate-first/support/issues/231

Bring in the content from: https://github.com/open-infrastructure-labs/operate-first-workloads

- Excludes `LICENSE`
- Moves the `README.md` into `docs/intro.md`
- Brings all commits with it