### PR TITLE
fix: Change description of area where you list users in the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding_to_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/onboarding_to_cluster.yaml
@@ -70,11 +70,7 @@ body:
           description: |
               Please list all users that will require access to the selected cluster.
 
-              Your OpenShift username is the email address associated with the
-              Google account you use to log in to the cluster. If you do not
-              wish to list email addresses in this issue (which is public), you
-              may reach out directly to an operate-first team member to provide
-              that information.
+              Your OpenShift username is the Github username you use to log in to the cluster.
           placeholder: username, username
       validations:
           required: true


### PR DESCRIPTION
The description of text area in the Onbboard to a cluster issue was not updated to reflect that we are using Github usernames instead of e-mails. So I have changed it to avoid confusion.