### PR TITLE
Adding Morty cluster option to the onboarding_to_cluster.yaml dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding_to_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/onboarding_to_cluster.yaml
@@ -12,7 +12,7 @@ body:
               Please select a cluster.
           options:
               - Infra
-              - Rick
+              - Morty
               - Smaug
               - Balrog
     - type: input


### PR DESCRIPTION
I'm adding the Morty cluster to the dropdown list under "Target cluster" in the template [here](https://github.com/operate-first/support/issues/new?assignees=first-operator&labels=kind%2Fonboarding%2Carea%2Fcluster&template=onboarding_to_cluster.yaml&title=NEW+PROJECT%3A+%3Cname%3E)

I've also removed the Rick cluster since it is being decommissioned and no new workloads are being added there (I think).