### PR TITLE
updating the onboarding_to_cluster docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
@@ -9,11 +9,14 @@ body:
       attributes:
           label: Target cluster
           description: |
-              Please select a cluster.
+              Please select a cluster from the list.
           options:
-              - Infra
               - Smaug
+              - Infra
+              - Morty
               - Balrog
+              - OSC-CL1
+              - OSC-CL2
     - type: input
       id: team-name
       attributes:
@@ -100,6 +103,15 @@ body:
           description: |
               If you selected "custom" in previous step, please specify your desired quota here.
           placeholder: 1CPU, 20GiB memory, 30GiB storage
+      validations:
+          required: false
+    - type: input
+      id: documentation
+      attributes:
+          label: Documentation Link
+          description: |
+              If you have any available documentation on your product, please provide the link here.
+          placeholder: https://www.operate-first.cloud
       validations:
           required: false
     - type: markdown


### PR DESCRIPTION
includes changes to available cluster list, updating documentation link to `prod/moc` cluster-scope overlay, and adding new input for link to the new project's documentation.

Addresses: https://github.com/operate-first/support/issues/547#issuecomment-1083408585 Task 1

Furthermore, pre-commit was failing due to deprecated `git` protocol for repos.
Related to: https://github.com/thoth-station/thoth-application/issues/2111