### PR TITLE
fix: name changes to align with robozome

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
@@ -11,10 +11,10 @@ body:
           description: |
               Please select a cluster.
           options:
-              - Infra
-              - Morty
-              - Smaug
-              - Balrog
+              - moc/infra
+              - emea/morty
+              - moc/smaug
+              - emea/balrog
     - type: input
       id: team-name
       attributes:
@@ -37,7 +37,7 @@ body:
       validations:
           required: true
     - type: input
-      id: project-name
+      id: namespace
       attributes:
           label: Desired project names
           description: |


### PR DESCRIPTION
Changed the sames of the clusters so robozome controller does not have to edit name received from issue.
Change project name id to namespace for clarity and use by the mustache cli.