### PR TITLE
Update issue templates to have environment and cluster merged

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/4_onboarding_to_cluster.yaml
@@ -12,19 +12,9 @@ body:
       description: |
         Please select a cluster.
       options:
-        - Infra
-        - Smaug
-        - Jerry
-  - type: dropdown
-    id: environment
-    attributes:
-      multiple: false
-      label: Target environment
-      description: |
-        Please select an environment.
-      options:
-        - moc
-        - emea
+        - MOC/Infra
+        - MOC/Smaug
+        - EMEA/Jerry
   - type: input
     id: team-name
     attributes:

--- a/.github/ISSUE_TEMPLATE/5_offboarding_from_a_cluster.yaml
+++ b/.github/ISSUE_TEMPLATE/5_offboarding_from_a_cluster.yaml
@@ -12,19 +12,9 @@ body:
       description: |
         Please select a cluster.
       options:
-        - Infra
-        - Smaug
-        - Jerry
-  - type: dropdown
-    id: environment
-    attributes:
-      multiple: false
-      label: Target environment
-      description: |
-        Please select an environment.
-      options:
-        - moc
-        - emea
+        - MOC/Infra
+        - MOC/Smaug
+        - EMEA/Jerry
   - type: input
     id: team-name
     attributes:


### PR DESCRIPTION
As for example in the issue https://github.com/operate-first/support/issues/1141 users might forget to specify environment. This change merges these two inputs into one which should lead to less errors

